### PR TITLE
enable dangerous pointer in python builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusion-blossom"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Yue Wu <wuyue16pku@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ classifiers = [
 # by default remove blossom V in the build because of license issue;
 # users can enable blossom V by removing `remove_blossom_v` feature, at the responsibility of users
 [tool.maturin]
-# features = ["python_binding", "remove_blossom_v", "u32_index", "dangerous_pointer"]
-features = ["python_binding", "remove_blossom_v"]
+features = ["python_binding", "remove_blossom_v", "dangerous_pointer", "u32_index", "i32_weight"]
 # Yue 2022.10.8: when maturin is called from `pip wheel`, it doesn't enable the above features, and thus pyo3 is not enabled
 #     since it cannot find pyo3, it falls back to use cffi (which is really confusing because I don't use cffi at all!)
 #     in order to solve cffi issue, I append "cffi" after requires = ["maturin>=0.12,<0.13"], and it works and generate some wheels
@@ -40,5 +39,4 @@ features = ["python_binding", "remove_blossom_v"]
 #     later on I realize I have to provide the features in `cargo-extra-args` (credit to https://github.com/PyO3/maturin/issues/211)
 # conclusion: when calling `maturin develop`, it can read `features` above; but when called from `pip wheel`, it takes value below
 bindings = "pyo3"
-# cargo-extra-args = "--features python_binding,remove_blossom_v,u32_index,dangerous_pointer"
-cargo-extra-args = "--features python_binding,remove_blossom_v"
+cargo-extra-args = "--features python_binding,remove_blossom_v,dangerous_pointer,u32_index,i32_weight"


### PR DESCRIPTION
The dangerous pointer feature is stable now. Especially in serial solvers, there is no reason to use excessive locks anymore. The locks are designed to pass Rust's memory safety checks, but they are carefully designed to not need any locks.