### PR TITLE
pointers: replace casts from `&T` to `&mut T` with unsafe cells

### DIFF
--- a/src/blossom_v.rs
+++ b/src/blossom_v.rs
@@ -12,7 +12,7 @@ cfg_if::cfg_if! {
             fn minimum_weight_perfect_matching(node_num: c_int, edge_num: c_int, edges: *const c_int, weights: *const c_int, matched: *mut c_int);
         }
 
-        pub fn safe_minimum_weight_perfect_matching(node_num: usize, weighted_edges: &Vec<(usize, usize, u32)>) -> Vec<usize> {
+        pub fn safe_minimum_weight_perfect_matching(node_num: usize, weighted_edges: &[(usize, usize, u32)]) -> Vec<usize> {
             let edge_num = weighted_edges.len();
             let mut edges = Vec::with_capacity(2 * edge_num);
             let mut weights = Vec::with_capacity(edge_num);
@@ -51,7 +51,7 @@ cfg_if::cfg_if! {
 
     } else {
 
-        pub fn safe_minimum_weight_perfect_matching(_node_num: usize, _weighted_edges: &Vec<(usize, usize, u32)>) -> Vec<usize> {
+        pub fn safe_minimum_weight_perfect_matching(_node_num: usize, _weighted_edges: &[(usize, usize, u32)]) -> Vec<usize> {
             unimplemented!("need blossom V library, see README.md")
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -492,7 +492,7 @@ impl Cli {
                                 ]);
                             }
                         }
-                        let command_head = vec![format!(""), format!("benchmark")];
+                        let command_head = [String::new(), "benchmark".to_string()];
                         let mut command_tail = vec!["--total-rounds".to_string(), format!("{TEST_EACH_ROUNDS}")];
                         if !disable_blossom {
                             command_tail.append(&mut vec![format!("--verifier"), format!("blossom-v")]);
@@ -622,7 +622,7 @@ impl Cli {
                                 ]);
                             }
                         }
-                        let command_head = vec![format!(""), format!("benchmark")];
+                        let command_head = [String::new(), "benchmark".to_string()];
                         let mut command_tail = vec![
                             format!("--primal-dual-type"),
                             format!("dual-parallel"),
@@ -755,7 +755,7 @@ impl Cli {
                                 ]);
                             }
                         }
-                        let command_head = vec![format!(""), format!("benchmark")];
+                        let command_head = [String::new(), "benchmark".to_string()];
                         let mut command_tail = vec![
                             format!("--primal-dual-type"),
                             format!("parallel"),

--- a/src/example_codes.rs
+++ b/src/example_codes.rs
@@ -368,7 +368,7 @@ pub trait ExampleCode {
 
     /// reorder the vertices such that new vertices (the indices of the old order) is sequential
     #[allow(clippy::unnecessary_cast)]
-    fn reorder_vertices(&mut self, sequential_vertices: &Vec<VertexIndex>) {
+    fn reorder_vertices(&mut self, sequential_vertices: &[VertexIndex]) {
         let (vertices, edges) = self.vertices_edges();
         assert_eq!(vertices.len(), sequential_vertices.len(), "amount of vertices must be same");
         let old_to_new = build_old_to_new(sequential_vertices);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub fn fusion_mwpm(initializer: &SolverInitializer, syndrome_pattern: &SyndromeP
 
 /// fall back to use blossom V library to solve MWPM (install blossom V required)
 #[allow(clippy::unnecessary_cast)]
-pub fn blossom_v_mwpm(initializer: &SolverInitializer, defect_vertices: &Vec<VertexIndex>) -> Vec<VertexIndex> {
+pub fn blossom_v_mwpm(initializer: &SolverInitializer, defect_vertices: &[VertexIndex]) -> Vec<VertexIndex> {
     // this feature will be automatically enabled if you install blossom V source code, see README.md for more information
     if cfg!(not(feature = "blossom_v")) {
         panic!("need blossom V library, see README.md")
@@ -110,7 +110,7 @@ pub fn blossom_v_mwpm(initializer: &SolverInitializer, defect_vertices: &Vec<Ver
 pub fn blossom_v_mwpm_reuse(
     complete_graph: &mut CompleteGraph,
     initializer: &SolverInitializer,
-    defect_vertices: &Vec<VertexIndex>,
+    defect_vertices: &[VertexIndex],
 ) -> Vec<VertexIndex> {
     // first collect virtual vertices and real vertices
     let mut is_virtual: Vec<bool> = (0..initializer.vertex_num).map(|_| false).collect();
@@ -205,8 +205,8 @@ pub struct DetailedMatching {
 #[allow(clippy::unnecessary_cast)]
 pub fn detailed_matching(
     initializer: &SolverInitializer,
-    defect_vertices: &Vec<DefectIndex>,
-    mwpm_result: &Vec<DefectIndex>,
+    defect_vertices: &[DefectIndex],
+    mwpm_result: &[DefectIndex],
 ) -> Vec<DetailedMatching> {
     let defect_num = defect_vertices.len();
     let mut is_defect: Vec<bool> = (0..initializer.vertex_num).map(|_| false).collect();

--- a/src/pointers.rs
+++ b/src/pointers.rs
@@ -311,6 +311,7 @@ impl<T: FastClear> weak_table::traits::WeakElement for FastClearWeakRwLock<T> {
 
 cfg_if::cfg_if! {
     if #[cfg(feature="unsafe_pointer")] {
+        use std::cell::UnsafeCell;
 
         pub trait FastClearUnsafePtr<ObjType> where ObjType: FastClear {
 
@@ -338,11 +339,8 @@ cfg_if::cfg_if! {
             #[inline(always)]
             fn write(&self, active_timestamp: FastClearTimestamp) -> &mut ObjType {
                 unsafe {
-                    // https://stackoverflow.com/questions/54237610/is-there-a-way-to-make-an-immutable-reference-mutable
-                    let ptr = self.ptr();
-                    let const_ptr = ptr as *const Arc<ObjType>;
-                    let mut_ptr = const_ptr as *mut Arc<ObjType>;
-                    let ret = Arc::get_mut_unchecked(&mut *mut_ptr);
+                    let ptr = UnsafeCell::new(self.ptr().clone());
+                    let ret = Arc::get_mut_unchecked(&mut *ptr.get());
                     ret.debug_assert_dynamic_cleared(active_timestamp);  // only assert during debug modes
                     ret
                 }
@@ -357,11 +355,8 @@ cfg_if::cfg_if! {
             #[inline(always)]
             fn write_force(&self) -> &mut ObjType {
                 unsafe {
-                    // https://stackoverflow.com/questions/54237610/is-there-a-way-to-make-an-immutable-reference-mutable
-                    let ptr = self.ptr();
-                    let const_ptr = ptr as *const Arc<ObjType>;
-                    let mut_ptr = const_ptr as *mut Arc<ObjType>;
-                    Arc::get_mut_unchecked(&mut *mut_ptr)
+                    let ptr = UnsafeCell::new(self.ptr().clone());
+                    Arc::get_mut_unchecked(&mut *ptr.get())
                 }
             }
 
@@ -396,11 +391,8 @@ cfg_if::cfg_if! {
             #[inline(always)]
             fn write(&self) -> &mut ObjType {
                 unsafe {
-                    // https://stackoverflow.com/questions/54237610/is-there-a-way-to-make-an-immutable-reference-mutable
-                    let ptr = self.ptr();
-                    let const_ptr = ptr as *const Arc<ObjType>;
-                    let mut_ptr = const_ptr as *mut Arc<ObjType>;
-                    Arc::get_mut_unchecked(&mut *mut_ptr)
+                    let ptr = UnsafeCell::new(self.ptr().clone());
+                    Arc::get_mut_unchecked(&mut *ptr.get())
                 }
             }
 

--- a/src/primal_module_parallel.rs
+++ b/src/primal_module_parallel.rs
@@ -339,18 +339,19 @@ impl PrimalModuleParallel {
         }
     }
 
-    pub fn parallel_solve_step_callback<DualSerialModule: DualModuleImpl + Send + Sync, F: Send + Sync>(
+    pub fn parallel_solve_step_callback<DualSerialModule: DualModuleImpl + Send + Sync, F>(
         &mut self,
         syndrome_pattern: &SyndromePattern,
         parallel_dual_module: &DualModuleParallel<DualSerialModule>,
         mut callback: F,
     ) where
         F: FnMut(
-            &DualModuleInterfacePtr,
-            &DualModuleParallelUnit<DualSerialModule>,
-            &PrimalModuleSerialPtr,
-            Option<&GroupMaxUpdateLength>,
-        ),
+                &DualModuleInterfacePtr,
+                &DualModuleParallelUnit<DualSerialModule>,
+                &PrimalModuleSerialPtr,
+                Option<&GroupMaxUpdateLength>,
+            ) + Send
+            + Sync,
     {
         let thread_pool = Arc::clone(&self.thread_pool);
         *self.last_solve_start_time.write() = Instant::now();
@@ -512,7 +513,7 @@ impl PrimalModuleParallelUnitPtr {
 
     /// call this only if children is guaranteed to be ready and solved
     #[allow(clippy::unnecessary_cast)]
-    fn children_ready_solve<DualSerialModule: DualModuleImpl + Send + Sync, F: Send + Sync>(
+    fn children_ready_solve<DualSerialModule: DualModuleImpl + Send + Sync, F>(
         &self,
         primal_module_parallel: &PrimalModuleParallel,
         partitioned_syndrome_pattern: PartitionedSyndromePattern,
@@ -520,11 +521,12 @@ impl PrimalModuleParallelUnitPtr {
         callback: &mut Option<&mut F>,
     ) where
         F: FnMut(
-            &DualModuleInterfacePtr,
-            &DualModuleParallelUnit<DualSerialModule>,
-            &PrimalModuleSerialPtr,
-            Option<&GroupMaxUpdateLength>,
-        ),
+                &DualModuleInterfacePtr,
+                &DualModuleParallelUnit<DualSerialModule>,
+                &PrimalModuleSerialPtr,
+                Option<&GroupMaxUpdateLength>,
+            ) + Send
+            + Sync,
     {
         let mut primal_unit = self.write();
         if let Some(mocker) = &primal_unit.streaming_decode_mocker {
@@ -612,7 +614,7 @@ impl PrimalModuleParallelUnitPtr {
     }
 
     /// call on the last primal node, and it will spawn tasks on the previous ones
-    fn iterative_solve_step_callback<DualSerialModule: DualModuleImpl + Send + Sync, F: Send + Sync>(
+    fn iterative_solve_step_callback<DualSerialModule: DualModuleImpl + Send + Sync, F>(
         &self,
         primal_module_parallel: &PrimalModuleParallel,
         partitioned_syndrome_pattern: PartitionedSyndromePattern,
@@ -620,11 +622,12 @@ impl PrimalModuleParallelUnitPtr {
         callback: &mut Option<&mut F>,
     ) where
         F: FnMut(
-            &DualModuleInterfacePtr,
-            &DualModuleParallelUnit<DualSerialModule>,
-            &PrimalModuleSerialPtr,
-            Option<&GroupMaxUpdateLength>,
-        ),
+                &DualModuleInterfacePtr,
+                &DualModuleParallelUnit<DualSerialModule>,
+                &PrimalModuleSerialPtr,
+                Option<&GroupMaxUpdateLength>,
+            ) + Send
+            + Sync,
     {
         let primal_unit = self.read_recursive();
         // only when sequentially running the tasks will the callback take effect, otherwise it's unsafe to execute it from multiple threads

--- a/src/util.rs
+++ b/src/util.rs
@@ -601,7 +601,7 @@ pub struct PartitionedSolverInitializer {
 
 /// perform index transformation
 #[allow(clippy::unnecessary_cast)]
-pub fn build_old_to_new(reordered_vertices: &Vec<VertexIndex>) -> Vec<Option<VertexIndex>> {
+pub fn build_old_to_new(reordered_vertices: &[VertexIndex]) -> Vec<Option<VertexIndex>> {
     let mut old_to_new: Vec<Option<VertexIndex>> = (0..reordered_vertices.len()).map(|_| None).collect();
     for (new_index, old_index) in reordered_vertices.iter().enumerate() {
         assert_eq!(old_to_new[*old_index as usize], None, "duplicate vertex found {}", old_index);
@@ -613,7 +613,7 @@ pub fn build_old_to_new(reordered_vertices: &Vec<VertexIndex>) -> Vec<Option<Ver
 /// translate defect vertices into the current new index given reordered_vertices
 #[allow(clippy::unnecessary_cast)]
 pub fn translated_defect_to_reordered(
-    reordered_vertices: &Vec<VertexIndex>,
+    reordered_vertices: &[VertexIndex],
     old_defect_vertices: &[VertexIndex],
 ) -> Vec<VertexIndex> {
     let old_to_new = build_old_to_new(reordered_vertices);


### PR DESCRIPTION
Casting between immutable and mutable references can create undefined behaviour. Performing the cast through an UnsafeCell ensures noalias attributes are not being sent to LLVM.

closes: #36